### PR TITLE
특이사항을 체크할때 radioButton이 취소가 안되는 문제를 해결하였습니다.

### DIFF
--- a/natuur/src/components/Information/inputRow/RemarksRow.tsx
+++ b/natuur/src/components/Information/inputRow/RemarksRow.tsx
@@ -18,12 +18,13 @@ const RemarksRow: FC<OwnProps> = ({ radioType, setRadioType }) => (
     {radioList.map(result => (
       <S.CheckBoxItem checkBoxCase="Remarks" key={result.CHECK_BOX_CASE}>
         <S.CheckBox
-          type="radio"
+          type="checkbox"
           name="remarksRow"
           id={result.CHECK_BOX_CASE}
           value={result.CHECK_BOX_NAME}
-          onChange={({ currentTarget: { value } }) => setRadioType(value)}
-          onClick={() => radioType && setRadioType(undefined)}
+          onClick={({ currentTarget: { value } }) =>
+            radioType === value ? setRadioType("") : setRadioType(value)
+          }
         />
         <S.CircleLabel htmlFor={result.CHECK_BOX_CASE}>
           {radioType === result.CHECK_BOX_NAME && <S.AcceptCircle />}

--- a/natuur/src/components/personalnformation/idPhoto/MiddleRow.tsx
+++ b/natuur/src/components/personalnformation/idPhoto/MiddleRow.tsx
@@ -18,7 +18,7 @@ const MiddleRow: FC<OwnProps> = ({
 }) => {
   useEffect(() => {
     if (isGed) {
-      setMiddleSchool({ school: undefined });
+      setMiddleSchool({ school: "" });
     }
   },        [isGed]);
 


### PR DESCRIPTION
라디오 버튼을 onChange를 통해 동작 시키다 보니까 라디오 버튼 특성상 다시 클릭할 시에 아무런 동작을 하지 않는다. -> 따라서 `type="radio"`를 `type="checkbox"`로 변경 후 onClick을 이용하여 동작하게 하였다.